### PR TITLE
Update the stack.yaml with an fixed version of servant-client.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,10 @@
 resolver: lts-12.0
+
 packages:
 - .
+
+extra-deps:
+- git: git@github.com:cdepillabout/servant
+  commit: b17fc2b8d48ba6d25cd34799507643dd25a8c0b2
+  subdirs:
+  - servant-client


### PR DESCRIPTION
This is for https://github.com/cdepillabout/servant-checked-exceptions/issues/27.

I'm sorry that the error status functional of `servant-checked-exceptions` is not working.

To be honest, I've never actually used the error status functionality with `servant-client`.

I looked into this a little, and it appears that servant-client is swallowing up responses that are not 2XX:

https://github.com/haskell-servant/servant/blob/f9bcc15d0b1877187b33cbfe5fa6ef60625e17d0/servant-client/src/Servant/Client/Internal/HttpClient.hs#L172-L173

I modified servant-client to stop doing this [here](https://github.com/cdepillabout/servant/commit/b17fc2b8d48ba6d25cd34799507643dd25a8c0b2), and it appears that it works?

```sh
$ stack build --fast && stack exec sce
Right (ErrEnvelope (Identity BadReq))
```

Although I'm not sure what the ramifications are of modifying servant-client like above.  

Maybe servant-client's `ClientEnv` type could have a configuration option that stops servant-client from performing this check?  Or maybe there is some way to fix servant-checked-exceptions to not hit this code path?

If you want to open up an issue about this on the servant repo, I will provide any support necessary to get this fixed.